### PR TITLE
Set chart filename to appropriate exporting option.

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -182,7 +182,7 @@
     function getContent(chart, href, extension, content, MIME) {
         var a,
             blobObject,
-            name = (chart.title ? chart.title.textStr.replace(/ /g, '-').toLowerCase() : 'chart'),
+            name = (chart.options.exporting.filename ? chart.options.exporting.filename : 'chart'),
             options = (chart.options.exporting || {}).csv || {},
             url = options.url || 'http://www.highcharts.com/studies/csv-export/download.php';
 


### PR DESCRIPTION
Updated export-csv plug-in to use exporting filename option to be consistent with exporting module.
